### PR TITLE
Removes user parameter from the configure method.

### DIFF
--- a/lib/generators/templates/access_policy.rb
+++ b/lib/generators/templates/access_policy.rb
@@ -1,7 +1,7 @@
 class AccessPolicy
   include AccessGranted::Policy
 
-  def configure(user)
+  def configure
     # Example policy for AccessGranted.
     # For more details check the README at
     #


### PR DESCRIPTION
The configure method in the generated access_policy.rb requires a user parameter. That's not consistent with the readme.